### PR TITLE
Created preset configuration dictionary for reusability between hardw…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ currently available for Windows and Linux operating systems. </p>
 
 <h2>Supported Boards:</h2>
 <p>
-L0002: Liquid Engine Controller (Rev 3/Rev 4)
+L0002: Liquid Engine Controller (Rev 3/Rev 4/Rev 5)
 
-A0002: Flight Computer (Rev 1)
+A0002: Flight Computer (Rev 2)
 
 L0005: Valve Controller (Rev 2)
 

--- a/controller.py
+++ b/controller.py
@@ -353,7 +353,7 @@ sensor_frame_sizes = {
 
                     # Engine Controller rev 5.0
                     controller_names[7]: 44
-                     }
+                    }
 
 # Sensor raw readout conversion functions
 sensor_conv_funcs = {
@@ -715,6 +715,80 @@ sensor_data_filenames = {
                         # Engine Controller rev 5.0
                         controller_names[7]: "output/engine_controller_rev5_sensor_data.txt"
                         }
+
+# How many sensor frames are needed for the presets
+preset_frames = {  
+                    # Engine Controller rev 4.0
+                    controller_names[2]: 0,
+
+                    # Flight Computer rev 1.0
+                    controller_names[3]: 0,
+
+                    # Flight Computer rev 2.0
+                    controller_names[4]: 1,
+
+                    # Flight Computer Lite rev 1.0
+                    controller_names[5]: 0,
+
+                    # Valve Controller rev 2.0
+                    controller_names[1]: 0,
+
+                    # Valve Controller rev 3.0
+                    controller_names[6]: 0,
+
+                    # Engine Controller rev 5.0
+                    controller_names[7]: 0
+}
+
+# Preset struct formats
+preset_sizes = {
+            # Flight Computer rev 2.0
+            controller_names[4]: {
+                # IMU offsets (24 bytes)
+                "accX" : 4,
+                "accY" : 4,
+                "accZ" : 4,
+                "gyroX": 4,
+                "gyroY": 4,
+                "gyroZ": 4,
+                # Baro preset (8 bytes)
+                "baroPres" : 4,
+                "baroTemp" : 4,
+                # Servo presets (4 bytes)
+                "servo1" : 1,
+                "servo2" : 1,
+                "servo3" : 1,
+                "servo4" : 1
+            }
+}
+
+# Sensor raw readout formats
+preset_formats = {
+            # Flight Computer rev 2.0
+            controller_names[4]: {
+                # IMU offsets (24 bytes)
+                "accX" : float,
+                "accY" : float,
+                "accZ" : float,
+                "gyroX": float,
+                "gyroY": float,
+                "gyroZ": float,
+                # Baro preset (8 bytes)
+                "baroPres" : float,
+                "baroTemp" : float,
+                # Servo presets (4 bytes)
+                "servo1" : int,
+                "servo2" : int,
+                "servo3" : int,
+                "servo4" : int
+            }
+}
+
+# Preset Data Filenames
+preset_filenames = {
+        # Flight Computer rev 2.0
+        controller_names[4]: "output/flight_comp_rev2_preset_data.txt"
+}
 
 # Firmware Ids
 firmware_ids = {

--- a/hw_commands.py
+++ b/hw_commands.py
@@ -274,6 +274,49 @@ def get_sensor_frames( controller, sensor_frames_bytes, format = 'converted' ):
 ####################################################################################
 #                                                                                  #
 # PROCEDURE:                                                                       #
+#         get_preset_values                                                        #
+#                                                                                  #
+# DESCRIPTION:                                                                     #
+#        Gets the preset values for a given controller type                        #
+#                                                                                  #
+####################################################################################
+def get_preset_values( controller, rx_byte_blocks, format = 'converted' ):
+
+    # Convert raw bytes into integer types
+    preset_bytes = rx_byte_blocks[0]
+    preset_bytes_int = []
+    for sensor_byte in preset_bytes:
+        preset_bytes_int.append( ord( sensor_byte ) )
+
+    # Parse integer bytes into preset values
+    # Start with save bits (universal)
+    preset_values = []
+    preset_values.append( preset_bytes_int[0] )
+    preset_values.append( preset_bytes_int[1] )
+
+    # Convert values and append to preset values
+    preset_frame_dict = {}
+    index = 2
+    for i, sensor in enumerate( preset_sizes[ controller ] ):
+        measurement = 0
+        float_bytes = []
+        for byte_num in range( preset_sizes[controller][sensor] ):
+            if ( preset_formats[controller][sensor] != float ):
+                measurement += ( preset_bytes_int[index + byte_num] << 8*byte_num )
+            else:
+                float_bytes.append( ( preset_bytes_int[index + byte_num] ).to_bytes(1, 'big' ) ) 
+        if ( preset_formats[controller][sensor] == float ):
+            measurement = byte_array_to_float( float_bytes )
+        preset_values.append(measurement)
+        index += preset_sizes[controller][sensor]
+
+    return preset_values
+## get_preset_values ##
+
+
+####################################################################################
+#                                                                                  #
+# PROCEDURE:                                                                       #
 #         format_sensor_readout                                                    #
 #                                                                                  #
 # DESCRIPTION:                                                                     #
@@ -1322,40 +1365,21 @@ def flash(Args, serialObj):
         # 4 bytes: Servo struct
         #   1 byte each x4: servo 1-4
 
-        # Convert raw bytes into integer types
-        preset_bytes = rx_byte_blocks[0]
-        preset_bytes_int = []
-        for sensor_byte in preset_bytes:
-            preset_bytes_int.append( ord( sensor_byte ) )
-
-        # Parse integer bytes into preset values
-        preset_values = []
-        preset_values.append( preset_bytes_int[0] )
-        preset_values.append( preset_bytes_int[1] )
-        #print ( "BYTES:" )
-        #print( preset_bytes )
-        for i in range(8): # 0-7
-            temp_array = []
-            for j in range(4): # 0-3
-                temp_array.append(preset_bytes_int[(4 * i) + j + 2].to_bytes(1,'big'))
-            preset_values.append( byte_array_to_float(temp_array) )
-        preset_values.append( preset_bytes_int[34] )
-        preset_values.append( preset_bytes_int[35] )
-        preset_values.append( preset_bytes_int[36] )
-        preset_values.append( preset_bytes_int[37] )
-
-        with open( "output/preset_values.txt", 'w' ) as file:
-            for value in preset_values:
-                file.write( str( value ) )
-                file.write( '\t' )
-            file.write( '\n' )
+        preset_blocks = preset_frames[serialObj.controller]
+        if (preset_blocks > 0):
+            preset_values = get_preset_values( serialObj.controller, rx_byte_blocks )
+            with open( preset_filenames[serialObj.controller], 'w' ) as file:
+                for value in preset_values:
+                    file.write( str( value ) )
+                    file.write( '\t' )
+                file.write( '\n' )
 
         # Convert the data from bytes to measurement readouts
         sensor_frames = get_sensor_frames( serialObj.controller, rx_byte_blocks )
 
         # Export the data to txt files
         with open( sensor_data_filenames[serialObj.controller], 'w' ) as file:
-            for sensor_frame in sensor_frames[1:]: # Start from index 1 instead of index 0
+            for sensor_frame in sensor_frames[preset_frames[serialObj.controller]:]: # Start from first non-preset frame instead of index 0
                 for val in sensor_frame:
                     file.write( str( val ) )
                     file.write( '\t')


### PR DESCRIPTION
Created preset configuration dictionary for reusability between hardware platforms. Moved preset parsing to helper function.

SDEC Issue #8

---

Glad we found time to do this. I feel a lot better about this functionality now that it shouldn't break other hardware platforms.

Testing outputs are attached. My first test used data from the previous implementation, and they had the same output.
![image](https://github.com/user-attachments/assets/0af66e60-9603-49fc-aa2f-495c3c04fb39)
[flight_comp_rev2_preset_data.txt](https://github.com/user-attachments/files/18894614/flight_comp_rev2_preset_data.txt)
[flight_comp_rev2_sensor_data.txt](https://github.com/user-attachments/files/18894615/flight_comp_rev2_sensor_data.txt)

