### PR TITLE
sdec-api returns and sensor-poll

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -310,11 +310,13 @@ def comports(Args, serialObj):
 	##############################################################################
 	if ( option == "-l" ):
 
+		ports = []
 		avail_ports = serial.tools.list_ports.comports()
 		print( "\nAvailable COM ports: " )
 		for port_num,port in enumerate( avail_ports ):
 			print( "\t" + str(port_num) + ": " + port.device + 
                    " - ", end="" ) 
+			ports.append(port.device)
 			if ( port.manufacturer != None ):
 				print( port.manufacturer + ": ", end="" )
 			if ( port.description  != None ):
@@ -322,7 +324,7 @@ def comports(Args, serialObj):
 			else:
 				print( "device info unavailable" )
 		print()
-		return serialObj
+		return serialObj, ports
 
 	##############################################################################
     # Help Option (-h)                                                           #
@@ -379,11 +381,11 @@ def comports(Args, serialObj):
 		connection_status = serialObj.closeComport()
 		if ( connection_status ):
 			print( "Disconnected from active serial port" )
-			return serialObj
+			return serialObj, "Disconnected"
 		else: 
 			print( "An error ocurred while closing port " + 
                    target_port )
-			return serialObj
+			return serialObj, "Error ocurred"
 
 	return serialObj
 ## comports ##
@@ -473,7 +475,7 @@ def ping( Args, serialObj ):
                                                            ping_time
                                                            )
                          )
-            return serialObj
+            return serialObj, "Response received at {0:1.4f} ms".format(ping_time)
 
         # Ping option 
         else:

--- a/commands.py
+++ b/commands.py
@@ -598,12 +598,15 @@ def connect( Args, serialObj ):
 					    firmware_version	
 									    )
 
-            # Display connection info									
-			print( "Connection established with " + 
-                    controller_descriptions[controller_response] )
+            # Display connection info	
+			api_status = []
+			description = controller_descriptions[controller_response]
+			print( "Connection established with " + description )
+			api_status.append("Connection established with " + description)
 			if ( serialObj.controller in firmware_id_supported_boards ):
 				print( "Firmware: " + firmware_version )
-			return serialObj
+				api_status.append("Firmware: " + firmware_version)
+			return serialObj, api_status
 		
 
 	##############################################################################

--- a/hw_commands.py
+++ b/hw_commands.py
@@ -671,9 +671,6 @@ def sensor( Args, serialObj, show_readouts = True ):
         filename = "canard_" + str(datetime.now()) + ".txt"
         file = open("canard/" + filename, "w")
 
-        # SDEC API poll file 
-        file_poll = open("poll.txt", "w")
-
         # Receive and display sensor readouts 
         timeout_ctr = 0
         try:    
@@ -694,9 +691,7 @@ def sensor( Args, serialObj, show_readouts = True ):
                                                             )
                     print( readout_formated + '\t', end='' )
                     file.write(readout_formated + '\t')
-                    file_poll.write(readout_formated + "\t")
                 file.write("\n")
-                file_poll.write("\n")
                 print()
                 # Pause for readibility
                 serialObj.sendByte( sensor_poll_cmds['WAIT'] )
@@ -709,7 +704,6 @@ def sensor( Args, serialObj, show_readouts = True ):
             serialObj.sendByte( sensor_poll_cmds['STOP'] )
 
         file.close()
-        file_poll.close()
 
         return serialObj
 

--- a/hw_commands.py
+++ b/hw_commands.py
@@ -545,6 +545,7 @@ def sensor( Args, serialObj, show_readouts = True ):
                                                         serialObj.sensor_readouts[sensor]
                                                         )
                 print( readout_formatted )
+                return serialObj, readout_formated
             
         return serialObj
 
@@ -663,7 +664,9 @@ def sensor( Args, serialObj, show_readouts = True ):
         # Canard Add-on feature: Logging data during poll
         filename = "canard_" + str(datetime.now()) + ".txt"
         file = open("canard/" + filename, "w")
-        
+
+        # SDEC API poll file 
+        file_poll = open("poll.txt", "w")
 
         # Receive and display sensor readouts 
         timeout_ctr = 0
@@ -685,7 +688,9 @@ def sensor( Args, serialObj, show_readouts = True ):
                                                             )
                     print( readout_formated + '\t', end='' )
                     file.write(readout_formated + '\t')
+                    file_poll.write(readout_formated + "\t")
                 file.write("\n")
+                file_poll.write("\n")
                 print()
                 # Pause for readibility
                 serialObj.sendByte( sensor_poll_cmds['WAIT'] )
@@ -698,6 +703,7 @@ def sensor( Args, serialObj, show_readouts = True ):
             serialObj.sendByte( sensor_poll_cmds['STOP'] )
 
         file.close()
+        file_poll.close()
 
         return serialObj
 

--- a/hw_commands.py
+++ b/hw_commands.py
@@ -523,9 +523,15 @@ def sensor( Args, serialObj, show_readouts = True ):
 
         print(sensor_dump_size_bytes)
 
+        # Readouts list for SDEC-API
+        readouts = []
+
         # Recieve data from controller
         for byteNum in range( sensor_dump_size_bytes ):
-            sensor_bytes_list.append( serialObj.readByte() )
+            to_append = serialObj.readByte()
+            #readouts.append(to_append) bytes not json readable
+            sensor_bytes_list.append( to_append)
+
 
         print(sensor_bytes_list)
 
@@ -545,9 +551,9 @@ def sensor( Args, serialObj, show_readouts = True ):
                                                         serialObj.sensor_readouts[sensor]
                                                         )
                 print( readout_formatted )
-                return serialObj, readout_formated
+                readouts.append(readout_formatted)
             
-        return serialObj
+        return serialObj, readouts
 
     ################################################################################
     # Subcommand: sensor pplot                                                      #

--- a/sdec.py
+++ b/sdec.py
@@ -274,7 +274,11 @@ if __name__ == '__main__':
         userArgs       = userin_clean[1:]
 
         # Execute Command
-        terminalSerObj = command_list[userCommand](userArgs, terminalSerObj)
+        execute = command_list[userCommand](userArgs, terminalSerObj)
+        if isinstance(execute, tuple): 
+            terminalSerObj, sdec_api_ignore = execute
+        else:
+            terminalSerObj = execute
 ## parseInput ##
 
 


### PR DESCRIPTION
Added necessary returns for sensor-poll.
Added necessary returns for the other sdec-api commands.
Handled when the returns are just the terminalSerObj or include data for sdec-api.