### PR TITLE
Set Project License: BSD-3-Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) 2025 Sun Devil Rocketry
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+pynput: Copyright (c) 2025 Moses Palmer. GNU Lesser General Public License v3. https://www.gnu.org/licenses/lgpl-3.0.en.html

--- a/appa.py
+++ b/appa.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
 
 ####################################################################################
 #                                                                                  #

--- a/canard_fc.py
+++ b/canard_fc.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 from pynput.keyboard import Key, Listener
 from functools import partial
 from hw_commands import byte_array_to_float

--- a/commands.py
+++ b/commands.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 ####################################################################################
 #                                                                                  #
 # Commands.py -- module with general command line functions                        #

--- a/config.py
+++ b/config.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 ####################################################################################
 #                                                                                  #
 # config.py -- Contains sdec global configuration parameters                       #

--- a/controller.py
+++ b/controller.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 ####################################################################################
 #                                                                                  #
 # controller.py -- Contains global variables with SDR controller information       #

--- a/engineController.py
+++ b/engineController.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 ####################################################################################
 #                                                                                  #
 # engineController.py -- module with engine controller specific command line       #

--- a/flightComputer.py
+++ b/flightComputer.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 #################################################################################### 
 #                                                                                  # 
 # flightComputer.py -- module with command line functions specific to the flight   # 

--- a/hw_commands.py
+++ b/hw_commands.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 #################################################################################### 
 #                                                                                  # 
 # hw_commands.py -- module with general command line functions with hardware       # 

--- a/parser.py
+++ b/parser.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 import matplotlib.pyplot
 import pandas as pd
 import matplotlib

--- a/plot_data.py
+++ b/plot_data.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 from matplotlib import pyplot as plt
 import numpy as np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "SDEC"
+license = { text = "BSD-3-Clause" }

--- a/sdec.py
+++ b/sdec.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 ####################################################################################
 #                                                                                  #
 # sdec.py -- main terminal program. Contains main program                          #

--- a/sensor_conv.py
+++ b/sensor_conv.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 ####################################################################################
 #                                                                                  # 
 # sensor_conv.py -- Functions for converting raw sensor data                       # 

--- a/sensor_plot.py
+++ b/sensor_plot.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 import time
 import numpy                    as np
 from   matplotlib import pyplot as plt

--- a/valveController.py
+++ b/valveController.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
 #################################################################################### 
 #                                                                                  #
 # valveController.py -- module with valve controller specific command line         #


### PR DESCRIPTION
Set the project license to BSD-3-Clause. I chose this mainly because the other projects currently use this clause. Also, BSD-3-Clause is compatible with the licenses for the following external packages: serial, matplotlib, numpy, and pandas. The only conflict is pynput, which is licensed with the GNU Lesser General Public License v3. From what I can tell, this is a less restrictive license which means it's still acceptable to license the rest of the project under BSD-3-Clause. An appropriate notice was made in the NOTICE file. 